### PR TITLE
Potential fix for code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/webhooks.js
+++ b/webhooks.js
@@ -83,7 +83,7 @@ async function handlePagesEvent(payload) {
   
   try {
     const existingRecord = await fetchExistingDatabaseRecord(repoName);
-    console.log(`Existing record for ${repoName}:`, existingRecord);
+    console.log('Existing record for %s:', repoName, existingRecord);
     
     if (action === 'created' || action === 'updated') {
       await processCustomDomainChange(payload, existingRecord);


### PR DESCRIPTION
Potential fix for [https://github.com/shakerg/pages-proxy/security/code-scanning/1](https://github.com/shakerg/pages-proxy/security/code-scanning/1)

To fix this vulnerability, avoid placing untrusted data into the format string itself. Instead, provide a constant format string for the log function and supply user data as additional arguments or as interpolated values in non-format-string positions. For this specific issue, replace:

```js
console.log(`Existing record for ${repoName}:`, existingRecord);
```

with:

```js
console.log('Existing record for %s:', repoName, existingRecord);
```

This ensures that any special characters in `repoName` will be safely printed as a string, and will not be treated as format specifiers. This fix should occur only at the line flagged (line 86 in the shown code block within `handlePagesEvent`). No additional imports or dependencies are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
