### PR TITLE
Potential fix for code scanning alert no. 3: Use of externally-controlled format string

### DIFF
--- a/webhooks.js
+++ b/webhooks.js
@@ -142,7 +142,7 @@ async function handlePageBuildEvent(payload) {
   
   try {
     const existingRecord = await fetchExistingDatabaseRecord(repoName);
-    console.log(`Existing record for ${repoName}:`, existingRecord);
+    console.log('Existing record for %s:', repoName, existingRecord);
     console.log(`Fetching current CNAME for ${repoName} from GitHub Pages API...`);
     let pagesResult;
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/shakerg/pages-proxy/security/code-scanning/3](https://github.com/shakerg/pages-proxy/security/code-scanning/3)

The best way to fix this problem is to avoid directly embedding untrusted values in a format string passed as the first parameter to a logging method (in this case, `console.log`). Instead, use a format string with a `%s` placeholder (or `string`), and pass the user-provided value as an argument. This prevents any embedded format specifiers in `repoName` from being interpreted by `console.log`. In the context of this code, change line 145 from:

```js
console.log(`Existing record for ${repoName}:`, existingRecord);
```

to:

```js
console.log('Existing record for %s:', repoName, existingRecord);
```

No additional imports are needed since `console.log` is part of the standard library. No other changes in the surrounding code are required. Only edit the block on line 145 where the dangerous string interpolation occurs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
