### PR TITLE
Potential fix for code scanning alert no. 4: Use of externally-controlled format string

### DIFF
--- a/webhooks.js
+++ b/webhooks.js
@@ -147,7 +147,7 @@ async function handlePageBuildEvent(payload) {
     let pagesResult;
     try {
       pagesResult = await fetchPagesCname(repoName);
-      console.log(`Current Pages API result for ${repoName}:`, pagesResult);
+      console.log('Current Pages API result for %s:', repoName, pagesResult);
     } catch (error) {
       if (error.status === 404) {
         console.log(`No GitHub Pages site found for ${repoName} (404 response)`);


### PR DESCRIPTION
Potential fix for [https://github.com/shakerg/pages-proxy/security/code-scanning/4](https://github.com/shakerg/pages-proxy/security/code-scanning/4)

To fix this issue, we should not interpolate potentially untrusted values such as `repoName` directly into the format string of a logging function, such as `console.log`. Instead, we should use a static format string containing a placeholder (`%s`), and then pass the untrusted value as a separate argument. This way, the value is safely inserted into the log message as a string, preventing any unintended interpretation of format specifiers. 

Specifically, in `webhooks.js`, line 150 inside `handlePageBuildEvent`, change:

```js
console.log(`Current Pages API result for ${repoName}:`, pagesResult);
```

to

```js
console.log('Current Pages API result for %s:', repoName, pagesResult);
```

No additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
